### PR TITLE
Fix line ending issues in windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
Hello,

Just after step 3 of [Development container](https://scilus.github.io/nf-neuro/pipeline/setup/#development-container) when installing on a windows computer, git reported that all files had been modified. In fact, it was only the end-of-line character.

I found a fix [here](https://code.visualstudio.com/docs/devcontainers/tips-and-tricks#_resolving-git-line-ending-issues-in-containers-resulting-in-many-modified-files) requiring the addition of a `.gitattributes` file.

In this last link, there are two other solutions, but they require modifying the user's git parameters.